### PR TITLE
CMakeList.txt corrects to allow using valhalla as a submodule in another CMakeList.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,10 +127,10 @@ find_package(Threads REQUIRED)
 
 # resolve vendored libraries
 set(date_include_dir ${VALHALLA_SOURCE_DIR}/third_party/date/include)
-set(rapidjson_include_dir ${CMAKE_SOURCE_DIR}/third_party/rapidjson/include)
-set(robinhoodhashing_include_dir ${CMAKE_SOURCE_DIR}/third_party/robin-hood-hashing/src/include)
+set(rapidjson_include_dir ${VALHALLA_SOURCE_DIR}/third_party/rapidjson/include)
+set(robinhoodhashing_include_dir ${VALHALLA_SOURCE_DIR}/third_party/robin-hood-hashing/src/include)
 set(cxxopts_include_dir ${VALHALLA_SOURCE_DIR}/third_party/cxxopts/include)
-set(dirent_include_dir ${CMAKE_SOURCE_DIR}/third_party/dirent/include)
+set(dirent_include_dir ${VALHALLA_SOURCE_DIR}/third_party/dirent/include)
 if (PREFER_EXTERNAL_DEPS)
   # date
   find_package(date QUIET)
@@ -320,7 +320,7 @@ endif()
 foreach(script valhalla_build_config valhalla_build_elevation
   valhalla_build_extract valhalla_build_timezones)
   configure_file(${VALHALLA_SOURCE_DIR}/scripts/${script} ${CMAKE_BINARY_DIR}/${script} COPYONLY)
-  
+
   install(
     FILES
       scripts/${script}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -208,11 +208,11 @@ set_target_properties(valhalla PROPERTIES
 # pkg-config installation
 if(PKG_CONFIG_FOUND)
   include(ValhallaPkgConfig)
-  
+
   configure_valhalla_pc()
 
   install(FILES
-    ${CMAKE_BINARY_DIR}/libvalhalla.pc
+    ${VALHALLA_BUILD_DIR}/libvalhalla.pc
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 endif()
 


### PR DESCRIPTION
CMakeList.txt corrects to allow using valhalla as a submodule in another CMakeList.txt

# Issue

What issue is this PR targeting? If there is no issue that addresses the problem, please open a corresponding issue and link it here.

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
